### PR TITLE
Fix warning on Elixir 1.11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule LoggerPapertrailBackend.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [],
+    [applications: [:logger],
     mod: { LoggerPapertrailBackend, []}]
   end
 


### PR DESCRIPTION
Fix warnings below by adding `:logger` to applications of mix

```
warning: Logger.compare_levels/2 defined in application :logger is used by the current application but the current application does not directly depend on :logger. To fix this, you must do one of:

  1. If :logger is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :logger is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :logger, you may optionally skip this warning by adding [xref: [exclude: Logger]] to your "def project" in mix.exs

  lib/logger_papertrail_backend/logger.ex:60: LoggerPapertrailBackend.Logger.meet_level?/2

warning: Logger.Formatter.compile/1 defined in application :logger is used by the current application but the current application does not directly depend on :logger. To fix this, you must do one of:

  1. If :logger is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :logger is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :logger, you may optionally skip this warning by adding [xref: [exclude: Logger.Formatter]] to your "def project" in mix.exs

  lib/logger_papertrail_backend/logger.ex:74: LoggerPapertrailBackend.Logger.configure/2

warning: Logger.Formatter.format/5 defined in application :logger is used by the current application but the current application does not directly depend on :logger. To fix this, you must do one of:

  1. If :logger is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :logger is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :logger, you may optionally skip this warning by adding [xref: [exclude: Logger.Formatter]] to your "def project" in mix.exs

  lib/logger_papertrail_backend/logger.ex:134: LoggerPapertrailBackend.Logger.format_event/5
```